### PR TITLE
Fixed #986 Route search results are not sorted by time correctly

### DIFF
--- a/Car.Backend/Car.Data/Constants/Constants.cs
+++ b/Car.Backend/Car.Data/Constants/Constants.cs
@@ -33,7 +33,7 @@
         public const double MaxLongitude = 180;
 
         public const double JourneySearchRadiusKm = 1;
-        public const double JourneySearchTimeScopeHours = 2;
+        public const double JourneySearchTimeScopeHours = 1;
 
         public const int OkStatusCode = 200;
     }

--- a/Car.Backend/Car.UnitTests/Services/JourneyServiceTest.cs
+++ b/Car.Backend/Car.UnitTests/Services/JourneyServiceTest.cs
@@ -1012,8 +1012,8 @@ namespace Car.UnitTests.Services
 
         [Theory]
         [InlineData("2121-1-1T12:00:00", "2121-1-1T12:00:00", 1, 1)]
-        [InlineData("2121-1-1T12:00:00", "2121-1-1T14:00:00", 1, 1)]
-        [InlineData("2121-1-1T12:00:00", "2121-1-1T10:00:00", 1, 1)]
+        [InlineData("2121-1-1T12:00:00", "2121-1-1T13:00:00", 1, 1)]
+        [InlineData("2121-1-1T12:00:00", "2121-1-1T11:00:00", 1, 1)]
         [InlineData("2121-1-1T12:00:00", "2121-1-1T15:00:00", 1, 0)]
         [InlineData("2121-1-1T12:00:00", "2121-1-1T09:00:00", 1, 0)]
         public void GetFilteredJourneys_FilteringByDepartureTime_ReturnsJourneysCollection(string journeyTime, string filterTime, int journeysToCreateCount, int expectedCount)


### PR DESCRIPTION
https://github.com/ita-social-projects/Car-Back-End/issues/986
Now it finds journeys which are in scope of 2 hours of our requested time (+- 1 hour)

For correct testing it is required to have the same time zone on your device with the device of journey creator, or you should count the difference between time zones